### PR TITLE
Configuração do pip-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # SAPI
+
+
+
+## Atualizando dependências
+
+A aplicação utiliza o pip-tools para gerenciamento das dependencias
+
+### instalando pip-tools
+
+```sh
+pip install --upgrade pip  # pip-tools precisa de pip>=6.
+pip install pip-tools
+```
+
+### instalando dependencias da aplicação
+
+Rode os comandos abaixo para a instalação das dependencias listadas no arquivo **requirements.txt**
+
+```sh
+pip install -r requirements.txt
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+opencv-python
+scikit-image


### PR DESCRIPTION
Adicionado ao projeto o pip-tools, um gerenciador de dependencias que irá facilitar a instalação e utilização de libs do Python. Adicionado também a descrição de instalação do mesmo bem como seu uso ao [README.mb](README.mb)